### PR TITLE
Remove image from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ version: '3'
 services:
   cfdd:
     build: .
-    image: cfdd
     restart: unless-stopped
     env_file: .env.production
     volumes:


### PR DESCRIPTION
Removed image option from docker-compose.yml as the container is built from scratch (using Dockerfile)